### PR TITLE
[Bugfix] Fixed /removecontaineracess route to be a post method instead of a delete method

### DIFF
--- a/daemon/src/lib/routers/pm.ts
+++ b/daemon/src/lib/routers/pm.ts
@@ -53,7 +53,7 @@ export function initPMRouter(this: ContainerWorkspaces) {
         }
     );
 
-    router.delete(
+    router.post(
         '/removecontaineraccess',
         requireBodyProps('token'),
         (req: Request, res: Response) => {


### PR DESCRIPTION
The reason is that a DELETE method shouldn't have a body.