### PR TITLE
[Bugfix] Fix multiple proxy clients bug

### DIFF
--- a/daemon/src/lib/proxy-manager/ProxyManager.ts
+++ b/daemon/src/lib/proxy-manager/ProxyManager.ts
@@ -33,7 +33,7 @@ export default class ProxyManager {
     protected readonly config: Configuration['proxy'];
     protected webApp: Application;
     protected accessTokens: Map<string, ProxyInfo>;
-    protected containerProxyClient: Map<number, BaseProxy>;
+    protected containerProxyClient: Map<string, BaseProxy>;
     protected authMiddleware: () => Handler;
     protected proxyRouter: Router;
     protected serviceRedirectRouter: Router;
@@ -162,9 +162,7 @@ export default class ProxyManager {
                 )
                     return socket.destroy();
 
-                let proxyClient = this.containerProxyClient.get(
-                    proxyInfo.containerID
-                );
+                let proxyClient = this.containerProxyClient.get(token);
                 if (!proxyClient) {
                     proxyClient = new this.proxyClients[proxyInfo.service](
                         {
@@ -179,10 +177,7 @@ export default class ProxyManager {
                         await proxyClient.fetchAuth();
                     }
 
-                    this.containerProxyClient.set(
-                        proxyInfo.containerID,
-                        proxyClient
-                    );
+                    this.containerProxyClient.set(token, proxyClient);
                 }
 
                 proxyClient.handleHttpUpgrade(request, socket, head);

--- a/daemon/src/lib/proxy-manager/proxyHandler.ts
+++ b/daemon/src/lib/proxy-manager/proxyHandler.ts
@@ -32,7 +32,8 @@ export default async function proxyHandler(
         });
     }
 
-    let proxyClient = this.containerProxyClient.get(proxyInfo.containerID);
+    const token: string = req.cookies['pm-token'];
+    let proxyClient = this.containerProxyClient.get(token);
     if (!proxyClient) {
         proxyClient = new this.proxyClients[proxyInfo.service](
             {
@@ -46,7 +47,7 @@ export default async function proxyHandler(
             await proxyClient.fetchAuth();
         }
 
-        this.containerProxyClient.set(proxyInfo.containerID, proxyClient);
+        this.containerProxyClient.set(token, proxyClient);
     }
 
     proxyClient.handleFetch(req, res);


### PR DESCRIPTION
Bug was that when a user would try to access a new proxy service when another one exists it would use the existing proxy client instead of using one for the intended service.