### PR TITLE
[Feature] Process data from proxmox and remove unnecessary endpoints

### DIFF
--- a/daemon/src/lib/proxmox/ProxmoxConnection.ts
+++ b/daemon/src/lib/proxmox/ProxmoxConnection.ts
@@ -58,6 +58,7 @@ import {
     setCTAsReady,
     updateIPUsedStatus,
     getClusterResources,
+    getSpecificContainerStatuses,
 } from './apiTools';
 
 export default class ProxmoxConnection {
@@ -121,6 +122,7 @@ export default class ProxmoxConnection {
     public getContainers = getContainers;
     public getClusterResources = getClusterResources;
     public getContainerStatuses = getContainerStatuses;
+    public getSpecificContainerStatuses = getSpecificContainerStatuses;
     public scoreNode = scoreNode;
     public createBackup = createBackup;
     public deleteBackup = deleteBackup;

--- a/daemon/src/lib/typing/types.ts
+++ b/daemon/src/lib/typing/types.ts
@@ -82,6 +82,11 @@ export interface CommandError {
 
 export type MessageRoutingHandler = MessageRouting[keyof MessageRouting];
 
+export type ResponseContainer = ContainerStatus & {
+    ip: string;
+    ready: boolean;
+};
+
 /**
  * This interface is used to define an LXC container in the PVE api
  * @interface


### PR DESCRIPTION
Removed unnecessary routes and using resources endpoint instead of fetching individual container statuses

Deleted /api/container/status and moved it to /api/container Deleted /api/container/:containerID/status and moved it to /api/container/:containerID